### PR TITLE
Handle null or empty dish.Photo in Index.cshtml

### DIFF
--- a/SolidLayer Architecture/Pages/Index.cshtml
+++ b/SolidLayer Architecture/Pages/Index.cshtml
@@ -28,6 +28,10 @@
                     {
                         <img src="@dish.Photo" alt="@dish.Name" width="100" />
                     }
+                    else
+                    {
+                        <p>no image</p>
+                    }
                 </td>
             </tr>
         }


### PR DESCRIPTION
Added an else block to display "no image" text when dish.Photo is null or empty. This ensures that the table cell always contains content, even if no image is available for the dish.